### PR TITLE
powerup time left status bar implemented

### DIFF
--- a/public/js/Camera.js
+++ b/public/js/Camera.js
@@ -19,7 +19,15 @@ class Camera {
   }
 
   update() {
-    this.x = this.sceneManager.Zerlin.x - cc.ZERLIN_POSITION_ON_SCREEN * this.width;
+    if (this.sceneManager.Zerlin.x - cc.ZERLIN_POSITION_ON_SCREEN * this.width >= 0) {
+      this.x = this.sceneManager.Zerlin.x - cc.ZERLIN_POSITION_ON_SCREEN * this.width;
+    } else if (this.x < 0) {
+      this.x = 0;
+    }
+    
+    
+    //console.log(this.x);
+    
   }
 
   draw() {

--- a/public/js/Camera.js
+++ b/public/js/Camera.js
@@ -19,10 +19,14 @@ class Camera {
   }
 
   update() {
-    if (this.sceneManager.Zerlin.x - cc.ZERLIN_POSITION_ON_SCREEN * this.width >= 0) {
+    if (this.sceneManager.Zerlin.x - cc.ZERLIN_POSITION_ON_SCREEN * this.width >= 0 &&
+        this.sceneManager.Zerlin.x <= this.sceneManager.level.getLengthAtI(7)) {
       this.x = this.sceneManager.Zerlin.x - cc.ZERLIN_POSITION_ON_SCREEN * this.width;
     } else if (this.x < 0) {
       this.x = 0;
+    // } else if (this.x > this.sceneManager.level.getLengthAtI(7)) {
+    //   console.log("edge of screen: " + this.x);
+    //   this.x = this.sceneManager.level.getLengthAtI(7);
     }
     
     

--- a/public/js/CollisionManager.js
+++ b/public/js/CollisionManager.js
@@ -209,10 +209,11 @@ class CollisionManager {
           zerlin.boundingbox.x, zerlin.boundingbox.y, zerlin.boundingbox.width, zerlin.boundingbox.height)) {
 
         //play power up pickup sound
-
+        this.sceneManager.addActivePowerup(powerup);
         // call the powerup effect.
         powerup.effect();
         powerup.playSound();
+
         powerup.removeFromWorld = true;
       }
 

--- a/public/js/CollisionManager.js
+++ b/public/js/CollisionManager.js
@@ -490,7 +490,6 @@ class CollisionManager {
         if (collidePointWithCircle(bossCenterX, bossCenterY, zerlin.lightsaber.airbornSaber.x, zerlin.lightsaber.airbornSaber.y, zerlin.lightsaber.airbornSaber.radius)) {
           this.sceneManager.boss.currentHealth -= zc.AIRBORN_SABER_DAMAGE;
           this.sceneManager.addEntity(new DroidExplosion(this.game, bossCenterX, bossCenterY, .7, .2));
-          console.log("hihihi");
         }
       }
     }

--- a/public/js/Constants.js
+++ b/public/js/Constants.js
@@ -21,8 +21,8 @@ Constants = {
   },
 
   DroidBasicConstants: {
-    BASIC_DROID_SHOOT_INTERVAL: 2, //default 2
-    BASIC_DROID_X_MOVEMENT_SPEED: 350,
+    BASIC_DROID_SHOOT_INTERVAL: 1, //default 2
+    BASIC_DROID_X_MOVEMENT_SPEED: 250,
     BASIC_DROID_Y_MOVEMENT_SPEED: 100,
     BASIC_DROID_X_ACCELERATION: 400,
     BASIC_DROID_Y_ACCELERATION: 100,
@@ -39,7 +39,7 @@ Constants = {
     BASIC_DROID_LASER_WIDTH: 10,
 
     /* This is actually spray droid? leggy droid constants */
-    LEGGY_DROID_SHOOT_INTERVAL: 4,
+    LEGGY_DROID_SHOOT_INTERVAL: 2,
     LEGGY_DROID_LASER_SPEED: 350,
     LEGGY_DROID_LASER_LENGTH: 25,
     LEGGY_DROID_LASER_WIDTH: 12,
@@ -49,7 +49,7 @@ Constants = {
     SPRAY_LASER_WIDTH_RADIANS: Math.PI / 6,
 
     /* beam droid constants */
-    BEAM_DROID_SHOOT_INTERVAL: 6,
+    BEAM_DROID_SHOOT_INTERVAL: 4,
     BEAM_DROID_SHOOT_DURATION: 2,
     BEAM_DROID_LASER_WIDTH: 16,
     BEAM_HP_PER_SECOND: 3,
@@ -60,14 +60,14 @@ Constants = {
     SLOWBURST_DROID_LASER_SPEED: 350,
     SLOWBURST_DROID_BURSTS: 4,
     // (how many shots are SKIPPED) + BURST_DROID_BURSTS in overall interval
-    SLOWBURST_DROID_SHOOTS_PER_CYCLE: 20,
+    SLOWBURST_DROID_SHOOTS_PER_CYCLE: 10,
 
     /* fast burst laser constants */
     FASTBURST_DROID_SHOOT_INTERVAL: .1,
     FASTBURST_DROID_LASER_SPEED: 550,
     FASTBURST_DROID_BURSTS: 3,
     // (how many shots are SKIPPED) + BURST_DROID_BURSTS in overall interval
-    FASTBURST_DROID_SHOOTS_PER_CYCLE: 80,
+    FASTBURST_DROID_SHOOTS_PER_CYCLE: 20,
 
     /* Sniper droid laser constants */
     SNIPER_DROID_LASER_SPEED: 850,
@@ -77,7 +77,7 @@ Constants = {
 
     /* multi-shot laser constants */
     MULTISHOT_DROID_SHOOT_INTERVAL: 2,
-    MULTISHOT_WIDTH: 35
+    MULTISHOT_WIDTH: 20
   },
 
   ZerlinConstants: {
@@ -85,7 +85,7 @@ Constants = {
 
     /* Zerlin health and force stats*/
     Z_MAX_HEALTH: 30, //was 20
-    Z_MAX_FORCE: 10,
+    Z_MAX_FORCE: 15,
     Z_FORCE_REGEN_PER_SECOND: 0.5,
     Z_FORCE_JUMP_FORCE_COST: 3,
     Z_SOMERSAULT_FORCE_COST: 3,
@@ -94,7 +94,7 @@ Constants = {
     Z_SLASH_DAMAGE: 10,
     Z_BOSS_BEAM_DAMAGE: 1,
 
-    Z_SCALE: 0.45, //was .55
+    Z_SCALE: 0.50, //was .55
 
     DRAW_COLLISION_BOUNDRIES: false,
 
@@ -109,7 +109,7 @@ Constants = {
     Z_HORIZANTAL_POSITION: 2 - PHI,
     Z_FEET_ABOVE_FRAME: 10,
 
-    Z_WALKING_FRAME_SPEED: .1,
+    Z_WALKING_FRAME_SPEED: .12,
     Z_WALKING_FRAMES: 6,
     Z_STANDING_FRAME_SPEED: .55,
     Z_STANDING_FRAMES: 2,
@@ -125,7 +125,7 @@ Constants = {
 
     Z_SLASH_WIDTH: 558,
     Z_SLASH_HEIGHT: 390,
-    Z_SLASH_FRAME_SPEED: .04,
+    Z_SLASH_FRAME_SPEED: .03,
     Z_SLASH_FRAMES: 20,
     Z_ARM_SOCKET_X_SLASH_FRAME: 69,
     Z_ARM_SOCKET_Y_SLASH_FRAME: 230,
@@ -142,8 +142,8 @@ Constants = {
     Z_DEATH_FRAMES: 30,
 
 
-    Z_WALKING_SPEED: 240,
-    Z_SOMERSAULT_SPEED: 450,
+    Z_WALKING_SPEED: 200,
+    Z_SOMERSAULT_SPEED: 400,
     FORCE_JUMP_DELTA_Y: -950,
     JUMP_DELTA_Y: -600,
     GRAVITATIONAL_ACCELERATION: 1000,
@@ -298,9 +298,7 @@ Constants = {
     POWERUP_BAR_Y: 50,
     POWERUP_PAD_X: 80,
     POWERUP_LINE_LENGTH: 30,
-    POWERUP_LENGTH: 50,
-
-
+    POWERUP_LENGTH: 40,
   },
 
   CameraConstants: {
@@ -356,24 +354,24 @@ Constants = {
     //I think becuase of the powerup scale, they need to be 2 row higher than where you want it.
     //can modify Z_SPAWN_X to make zerlin spawn later in the level.
     MIKE_LEVEL_ONE: [
-      '                                                                                          I     d  n                               ',
-      '                                    d                                                              f                               ',
-      '                                                                    s                        m  d     n                            ',
-      '                                        d                                                         f                           I    ',
-      '                                  s            d                            s              -   m                                   ',
-      '                             d                  f                            n                                                     ',
-      '               d                                s         d       s         f b         =                                          ', //from ground can force jump to here.
-      '                                                                             d                               ---                   ',
-      '                                               f b                          f d        d                                           ', //halfway of camera height.
-      '                          d       d                                                                         ==                     ',
-      '                                            --------                          d                                                    ',
-      '                                   S                                   C             T                                             ',
-      '                  -----                               H                   ---                       H F          --                ',
-      '                                       ----                                                                                        ',
-      '           ------                             I           -----       ---            -                      ---       --           ', //from ground level, can reg. jump to here.
-      '                                 -----             ----                        --           S       - -                            ',
-      '                                                                            -                                                      ',
-      '------------           -- -- ----            --------   --     --- ---------  -- ---- ---------------------------------------------'],
+      '                                                                                                S                          ',
+      '                                                                                                                           ',
+      '                     d                                                                                                     ',
+      '                                                                                                                           ',
+      '                                                                                           -------                        d',
+      '                                                                                                                           ',
+      '                                                                                        =                                  ', //from ground can force jump to here.
+      '                                                                                                            ---            ',
+      '                                                                                                                           ', //halfway of camera height.
+      '                                                                                                            ==             ',
+      '                                                                                                                           ',
+      '                                            --------        C                                                              ',
+      '                  -----                                                   ---                       H F          --        ',
+      '                                       ----                                                                                ',
+      '           ------                             I           -----       ---     ----                          ---       --   ', //from ground level, can reg. jump to here.
+      '                                 -----             ----                                             - -                    ',
+      '                                                                                                                           ',
+      '------------           -- -- ----            --------   --     --- ---             ----------------------------------------'],
     //   ^      ^- just on screen on start camera location.
     //   |-> Zerlin spawn point.
     //can jump 1 column

--- a/public/js/Constants.js
+++ b/public/js/Constants.js
@@ -98,7 +98,7 @@ Constants = {
 
     DRAW_COLLISION_BOUNDRIES: false,
 
-    Z_SPAWN_X: 0, //modify this to spawn zerlin later in the level.
+    Z_SPAWN_X: 11000, //modify this to spawn zerlin later in the level.
     //about 100 for 1 tile/column.
 
     Z_WIDTH: 114,
@@ -354,45 +354,45 @@ Constants = {
     //I think becuase of the powerup scale, they need to be 2 row higher than where you want it.
     //can modify Z_SPAWN_X to make zerlin spawn later in the level.
     MIKE_LEVEL_ONE: [
-      '                                                                                                S                          ',
-      '                                                                                                                           ',
-      '                     d                                                                                                     ',
-      '                                                                                                                           ',
-      '                                                                                           -------                        d',
-      '                                                                                                                           ',
-      '                                                                                        =                                  ', //from ground can force jump to here.
-      '                                                                                                            ---            ',
-      '                                                                                                                           ', //halfway of camera height.
-      '                                                                                                            ==             ',
-      '                                                                                                                           ',
-      '                                            --------        C                                                              ',
-      '                  -----                                                   ---                       H F          --        ',
-      '                                       ----                                                                                ',
-      '           ------                             I           -----       ---     ----                          ---       --   ', //from ground level, can reg. jump to here.
-      '                                 -----             ----                                             - -                    ',
-      '                                                                                                                           ',
-      '------------           -- -- ----            --------   --     --- ---             ----------------------------------------'],
+      '                                                                                                S                             ',
+      '                                                                                                                              ',
+      '                     d                                                                                                        ',
+      '                                                                                                                              ',
+      '                                                                                           -------                        d   ',
+      '                                                                                                                              ',
+      '                                                                                        =                                     ', //from ground can force jump to here.
+      '                                                                                                            ---               ',
+      '                                                                                                                              ', //halfway of camera height.
+      '                                                                                                            ==                ',
+      '                                                                                                                              ',
+      '                                            --------        C                                                                 ',
+      '                  -----                                                   ---                   H F              --           ',
+      '                                       ----                                                                                   ',
+      '           ------                             I           -----       ---     ----                          ---       --      ', //from ground level, can reg. jump to here.
+      '                                 -----             ----                                         - -                           ',
+      '                                                                                                                              ',
+      '------------           -- -- ----            --------   --     --- ---             -------------------------------------------'],
     //   ^      ^- just on screen on start camera location.
     //   |-> Zerlin spawn point.
     //can jump 1 column
     //can roll 2 columns
     CITY_LEVEL: [                                                                                                                                                                                                                                                          // level length
       '                    b                                                                                                                                                     n                          d                                                                                                      ',
-      '                                                                                                                                                                                                              d                                                          s',
-      '                                                                                                                                                                                                         m                                    *                            ',
-      '                                                                                                                                                                                                                                                                           ',
-      '                                                                                                                                                                                                                                                                   f       ',
-      '                                                                                                                                                                m                                                                                                          ',
-      '                                                                                                                                                                            I                                                                          I                    ', //from ground can force jump to here.
-      '                                                                                            f                                                                                                                                                                               ',
-      '                                                                                                                                                                                                                                                        ~-~                    ', //halfway of camera height.
-      '                                                                            H                                                                                                                                                                                          *        ',
-      '                                       m                 f                                   b                                                                                                              s                           ----                                    ',
-      '           s         ~                                                     ~         s                                                        ===                          -                     m       f                                                                     ',
+      '                                                                                                                                                                                                              d                                                          s        ',
+      '                                                                                                                                                                                                         m                                    *                                   ',
+      '                                                                                                                                                                                                                                                                                  ',
+      '                                                                                                                                                                                                                                                                   f              ',
+      '                                                                                                                                                                m                                                                                                                 ',
+      '                                                                                                                                                                            I                                                                          I                          ', //from ground can force jump to here.
+      '                                                                                            f                                                                                                                                                                                     ',
+      '                                                                                                                                                                                                                                                        ~-~                       ', //halfway of camera height.
+      '                                                                            H                                                                                                                                                                                          *          ',
+      '                                       m                 f                                   b                                                                                                              s                           ----                                      ',
+      '           s         ~                                                     ~         s                                                        ===                          -                     m       f                                                                        ',
       '                                    F                          -~                 *                                                                                  m                      -                            ~~                 ~--~    ==                            ',
-      '                ~~                           ~  ~ ~~    H        -~    ~~                                  m                        d       --           b                     ~~~--~--  H      ---           b                                        ~~--~~                              ',
-      '                          d         === ==                  -~            ~-~~  --~---~--          ~~-~              b           -----~-~-                             ~~~~~~                                ---         -~        ===                             I      ~~~---~   ', //from ground level, can reg. jump to here. well higher now
-      '    ~                                                 ==  =                                ~~~~ --                                        I ----             ---~~-~~                =======          ~~--~          ~~                 F                                          ~~ ',
+      '                ~~                           ~  ~ ~~    H        -~    ~~                                  m                        d       --           b                     ~~~--~--  H      ---           b                                        ~~--~~                     ',
+      '                          d         === ==                  -~            ~-~~  --~---~--          ~~-~              b           -----~-~-                             ~~~~~~                                ---         -~        ===                             I      ~~~---~ ', //from ground level, can reg. jump to here. well higher now
+      '    ~                                                 ==  =                                ~~~~ --                                        I ----             ---~~-~~                =======          ~~--~          ~~                 F                                         ',
       '        --~~       --             ~     d                        ~~~  =  =        H   F                =====  ~~         ~-~-----                ~~ --~--~-                  =                      n                         --     ----~~ -  ~~~---~~~~------------~~~-----     ',
       '~~~~ ~-               --   -~   --           --                                                                 ~~-~~              -                                                       f------------------~-~~-  --   --     --                                                '
     ],

--- a/public/js/Constants.js
+++ b/public/js/Constants.js
@@ -281,7 +281,7 @@ Constants = {
   StatusBarConstants: {
     STATUS_BAR_LENGTH: 0.25, // width of the canvas to use when drawing
     STATUS_BAR_WIDTH: 20,
-    STATUS_BAR_DISPLAY_TEXT: true,
+    STATUS_BAR_DISPLAY_TEXT: false,
 
     //when the current is less than or equal to the maxSize * CriticalAmount
     //then start alerting the user by using some graphics.
@@ -334,6 +334,29 @@ Constants = {
     *  =  leggy droid boss
     X  =  Boss
     */
+
+    MIKE_LEVEL_TWO: [
+      
+      '                                                                                                    ',
+      '                                                                                                    ',
+      '                                     ------                                                         ',
+      '                                                                                                    ',
+      '                                                                                                    ',
+      '                                ~~~                                                                 ',
+      '                                                                                                    ', //from ground can force jump to here.
+      '                                                                                                    ',
+      '                                                                                                    ', //halfway of camera height.
+      '                                                                                                    ',
+      '                          ~~~                                                                       ',
+      '                                                                -----                               ',
+      '                                                                                                    ',
+      '                                            ~~ ~ ~~ ~~~ ~~~~~~~                                     ',
+      '                                                                                                    ', //from ground level, can reg. jump to here.
+      '             ==  ==            --                                                                   ',
+      '                                                                                                    ',
+      '------------        ---- -----    ---------                                                         '],
+      //   ^      ^- just on screen on start camera location.
+      //   |-> Zerlin spawn point.
 
     LEVEL_ONE_TILE_LAYOUT: [
       '                                 ',

--- a/public/js/Constants.js
+++ b/public/js/Constants.js
@@ -98,7 +98,7 @@ Constants = {
 
     DRAW_COLLISION_BOUNDRIES: false,
 
-    Z_SPAWN_X: 11000, //modify this to spawn zerlin later in the level.
+    Z_SPAWN_X: 0, //modify this to spawn zerlin later in the level.
     //about 100 for 1 tile/column.
 
     Z_WIDTH: 114,

--- a/public/js/Constants.js
+++ b/public/js/Constants.js
@@ -22,7 +22,7 @@ Constants = {
 
   DroidBasicConstants: {
     BASIC_DROID_SHOOT_INTERVAL: 1, //default 2
-    BASIC_DROID_X_MOVEMENT_SPEED: 250,
+    BASIC_DROID_X_MOVEMENT_SPEED: 225,
     BASIC_DROID_Y_MOVEMENT_SPEED: 100,
     BASIC_DROID_X_ACCELERATION: 400,
     BASIC_DROID_Y_ACCELERATION: 100,
@@ -281,7 +281,7 @@ Constants = {
   StatusBarConstants: {
     STATUS_BAR_LENGTH: 0.25, // width of the canvas to use when drawing
     STATUS_BAR_WIDTH: 20,
-    STATUS_BAR_DISPLAY_TEXT: false,
+    STATUS_BAR_DISPLAY_TEXT: true,
 
     //when the current is less than or equal to the maxSize * CriticalAmount
     //then start alerting the user by using some graphics.
@@ -354,24 +354,24 @@ Constants = {
     //I think becuase of the powerup scale, they need to be 2 row higher than where you want it.
     //can modify Z_SPAWN_X to make zerlin spawn later in the level.
     MIKE_LEVEL_ONE: [
-      '                                                                                                S                             ',
+      '                          b      s                 d       d                   f d                     S    d      d          ',
+      '                    d                d              d      dds                   d                          f     f  d        ',
+      '                           d         d            d  b      db                    d                        b        d s       ',
+      '                     d                s             s                             s                                 I s       ',
+      '                                      d                                                     ------------            b d   d   ',
+      '              d                                                                                                      b        ',
+      '                                                                                        =      f        d            fd       ', //from ground can force jump to here.
+      '                                                                                                s      d    ---               ',
+      '                                                                                               d s                            ', //halfway of camera height.
+      '                                                                                    H F                     ==                ',
       '                                                                                                                              ',
-      '                     d                                                                                                        ',
-      '                                                                                                                              ',
-      '                                                                                           -------                        d   ',
-      '                                                                                                                              ',
-      '                                                                                        =                                     ', //from ground can force jump to here.
-      '                                                                                                            ---               ',
-      '                                                                                                                              ', //halfway of camera height.
-      '                                                                                                            ==                ',
-      '                                                                                                                              ',
-      '                                            --------        C                                                                 ',
-      '                  -----                                                   ---                   H F              --           ',
+      '                                            --------                                                                          ',
+      '                  -----                                                   ---       ---                          --           ',
       '                                       ----                                                                                   ',
-      '           ------                             I           -----       ---     ----                          ---       --      ', //from ground level, can reg. jump to here.
-      '                                 -----             ----                                         - -                           ',
+      '           ------                             I         H -----     C ---     ----                          ---       --      ', //from ground level, can reg. jump to here.
+      '                               S -----             ----                                        ---                            ',
       '                                                                                                                              ',
-      '------------           -- -- ----            --------   --     --- ---             -------------------------------------------'],
+      '------------           -- -- ----            --------   --     --- ---             -----------     ---------------------------'],
     //   ^      ^- just on screen on start camera location.
     //   |-> Zerlin spawn point.
     //can jump 1 column
@@ -397,7 +397,7 @@ Constants = {
       '~~~~ ~-               --   -~   --           --                                                                 ~~-~~              -                                                       f------------------~-~~-  --   --     --                                                '
     ],
 
-    LEVEL_THREE_TILE_LAYOUT: [
+    BOSS_TEST_LAYOUT: [
       '                 ',
       '           d     ',
       '  d   X          ',
@@ -434,7 +434,7 @@ Constants = {
 
     COIN_IMAGE_SCALE: .5,
 
-    SPLIT_SHOT_TIME: 7,
+    SPLIT_SHOT_TIME: 10,
     SPLIT_LASER_AMOUNT: 4,
     SPLIT_LASER_ARC_WIDTH: Math.PI / 9,
 

--- a/public/js/Constants.js
+++ b/public/js/Constants.js
@@ -291,7 +291,14 @@ Constants = {
     FORCE_BAR_HAS_CRITICAL_STATE: false,
 
     BOSS_BAR_LENGTH: 0.5,
-    BOSS_BAR_HAS_CRITICAL_STATE: false
+    BOSS_BAR_HAS_CRITICAL_STATE: false,
+
+    POWERUP_START_X: 375,
+    POWERUP_Y: 10,
+    POWERUP_BAR_Y: 50,
+    POWERUP_PAD_X: 80,
+    POWERUP_LINE_LENGTH: 30,
+    POWERUP_LENGTH: 50,
 
 
   },
@@ -305,6 +312,30 @@ Constants = {
     DRAW_BOXES: false,
     TILE_ACCELERATION: 200,
     TILE_INITIAL_VELOCITY: 200,
+
+    /*
+    Assets:
+    //powerups are capital
+
+    -  =  tile
+    =  =  moving tile
+    ~  =  falling tile
+    d  =  basic droid
+    s  =  scatter shot droid
+    b  =  slow burst droid
+    f  =  fast burst droid
+    m  =  multi-shot droid
+    n  =  sniper droid
+
+    H  =  health powerup
+    F  =  force powerup
+    I  =  invincibility powerup
+    S  =  split-shot powerup
+    T  =  tiny mode powerup
+
+    *  =  leggy droid boss
+    X  =  Boss
+    */
 
     LEVEL_ONE_TILE_LAYOUT: [
       '                                 ',
@@ -336,14 +367,13 @@ Constants = {
       '                                               f b                          f d        d                              X            ', //halfway of camera height.
       '                          d       d                                                                         ==                     ',
       '                                            --------                          d                                                    ',
-      '                                   S                                                 T                                             ',
+      '                                   S                                   C             T                                             ',
       '                  -----                               H                   ---                       H F          --                ',
       '                                       ----                                                                                        ',
-      '          C------                             I           -----       ---            -                      ---       --           ', //from ground level, can reg. jump to here.
+      '           ------                             I           -----       ---            -                      ---       --           ', //from ground level, can reg. jump to here.
       '                                 -----             ----                        --           S       - -                            ',
       '                                                                            -                                                      ',
-      '------------           -- -- ----            --------   --     --- ---------  -- ---- ---------------------------------------------'
-    ],
+      '------------           -- -- ----            --------   --     --- ---------  -- ---- ---------------------------------------------'],
     //   ^      ^- just on screen on start camera location.
     //   |-> Zerlin spawn point.
     //can jump 1 column
@@ -395,18 +425,22 @@ Constants = {
   PowerUpConstants: {
     HEALTH_SCALE: 3,
     RECOVER_HEALTH_AMOUNT: 20,
+
     RECOVER_FORCE_AMOUNT: 20,
     FORCE_SCALE: 3,
     DRAW_OUTLINES: false,
     FLOATING_MAGNITUDE: 12,
+
     INVINCIBILITY_SCALE: 2.5,
     INVINCIBILITY_TIME: 10,
+
     COIN_IMAGE_SCALE: .5,
+
     SPLIT_SHOT_TIME: 7,
     SPLIT_LASER_AMOUNT: 4,
     SPLIT_LASER_ARC_WIDTH: Math.PI / 9,
 
-    TINY_MODE_TIME: 20,
+    TINY_MODE_TIME: 10,
     SHRINKING_TIME: 1.5,
     TINY_SCALE: .2
   },

--- a/public/js/Constants.js
+++ b/public/js/Constants.js
@@ -364,7 +364,7 @@ Constants = {
       '                             d                  f                            n                                                     ',
       '               d                                s         d       s         f b         =                                          ', //from ground can force jump to here.
       '                                                                             d                               ---                   ',
-      '                                               f b                          f d        d                              X            ', //halfway of camera height.
+      '                                               f b                          f d        d                                           ', //halfway of camera height.
       '                          d       d                                                                         ==                     ',
       '                                            --------                          d                                                    ',
       '                                   S                                   C             T                                             ',

--- a/public/js/GameEngine.js
+++ b/public/js/GameEngine.js
@@ -30,7 +30,7 @@ class GameEngine {
       y: 100
     };
     this.click = null;
-    this.keys = {};
+    this.keys = {};    
   }
 
   init(ctx) {
@@ -39,10 +39,14 @@ class GameEngine {
     this.surfaceHeight = this.ctx.canvas.height;
     this.timer = new Timer(this);
     this.sceneManager = new SceneManager2(this);
-
     this.audio = new SoundEngine(this);
     this.startInput();
     this.sceneManager.init();
+
+    var godModeButton = document.getElementById("godMode");
+    godModeButton.addEventListener('click', event => {
+      this.sceneManager.toggleGodMode();
+    });
     console.log('game initialized');
   }
 
@@ -73,14 +77,6 @@ class GameEngine {
     this.ctx.clearRect(0, 0, this.surfaceWidth, this.surfaceHeight);
     this.ctx.save();
     this.sceneManager.draw();
-
-
-    // if (this.gameOver) {
-    //     this.ctx.textAlign = 'center';
-    //     this.ctx.font = '70px serif';
-    //     this.ctx.fillText('GAME OVER', this.camera.width / 2, this.camera.height / 2);
-    // }
-
 
     this.ctx.restore();
   }
@@ -156,14 +152,6 @@ class GameEngine {
   }
 
 }
-
-
-
-
-
-
-
-
 
 class Timer {
   constructor() {

--- a/public/js/GameEngine.js
+++ b/public/js/GameEngine.js
@@ -101,6 +101,7 @@ class GameEngine {
     }
 
     this.ctx.canvas.addEventListener("keydown", (e) => {
+      e.preventDefault();
       if (that.keys[e.code]) {
         return;
       } // prevent repeating calls when key is held down
@@ -112,7 +113,6 @@ class GameEngine {
         }
       }
       that.keys[e.code] = true;
-      e.preventDefault();
     }, false);
 
     this.ctx.canvas.addEventListener("keyup", function(e) {

--- a/public/js/HeroEntities.js
+++ b/public/js/HeroEntities.js
@@ -338,9 +338,23 @@ class Zerlin extends Entity {
 
   }
 
+  enableInvincibility() {
+    if (this.invincible) { //if already invincible reset the timer.
+      this.iSeconds = Constants.PowerUpConstants.INVINCIBILITY_TIME;
+    } else {
+      this.invincible = true;
+    }
+  }
+
+
   shrink() {
-    this.tiny = true;
-    this.tinyTimer = 0;
+    if (this.tiny) {
+      this.tinyTimer = 0;
+    } else {
+      this.tiny = true;
+      this.tinyTimer = 0;
+    }
+    
   }
 
   adjustTinyScale() {
@@ -771,6 +785,14 @@ class Lightsaber extends Entity {
     super.draw();
     if (this.airbornSaber) {
       this.airbornSaber.draw();
+    }
+  }
+
+  enableSplitLasers() {
+    if (this.splitLasers) { //if splitshot is already active, reset the timer
+      this.splitShotTimer = puc.SPLIT_SHOT_TIME;
+    } else {
+      this.splitLasers = true;
     }
   }
 

--- a/public/js/HeroEntities.js
+++ b/public/js/HeroEntities.js
@@ -348,20 +348,10 @@ class Zerlin extends Entity {
 
 
   shrink() {
-<<<<<<< HEAD
-    if (this.tiny) {
-      this.tinyTimer = 0;
-    } else {
-      this.tiny = true;
-      this.tinyTimer = 0;
-    }
-    
-=======
     if (!this.tiny) {
       this.tiny = true;
       this.tinyTimer = 0;
     }
->>>>>>> 7ad976c9683c3b982512cee0bc6fc966f0b8d274
   }
 
   adjustTinyScale() {

--- a/public/js/HeroEntities.js
+++ b/public/js/HeroEntities.js
@@ -14,6 +14,7 @@ class Zerlin extends Entity {
     // NOTE: this.x is CENTER of Zerlin, not left side of image. this.y is feet.
     super(game, game.surfaceWidth * camConst.ZERLIN_POSITION_ON_SCREEN + zc.Z_SPAWN_X, 0, 0, 0);
     this.sceneManager = sceneManager;
+    this.godMode = this.sceneManager.godMode;
     this.assetManager = game.assetManager;
     this.camera = camera;
     this.ctx = game.ctx;
@@ -40,9 +41,9 @@ class Zerlin extends Entity {
     this.faceRight();
 
     /* Zerlin Status' */
-    this.maxHealth = zc.Z_MAX_HEALTH;
+    this.maxHealth = this.godMode ? 999999: zc.Z_MAX_HEALTH ;
     this.currentHealth = this.maxHealth;
-    this.maxForce = zc.Z_MAX_FORCE;
+    this.maxForce = this.godMode ? 999999: zc.Z_MAX_FORCE;
     this.currentForce = this.maxForce;
 
     this.scale = zc.Z_SCALE;
@@ -59,6 +60,13 @@ class Zerlin extends Entity {
     this.poisoned = false;
     this.poisonedCounter = 0;
     this.poisonedMaxTime = Constants.DroidBossConstants.POISON_LASER_DURATION;
+  }
+
+  setHealth() {
+    this.maxHealth = this.godMode ? 999999: zc.Z_MAX_HEALTH ;
+    this.currentHealth = this.maxHealth;
+    this.maxForce = this.godMode ? 999999: zc.Z_MAX_FORCE;
+    this.currentForce = this.maxForce;
   }
 
   update() {
@@ -392,6 +400,8 @@ class Zerlin extends Entity {
       }
     }
   }
+
+  
 
   isTileBelow(tile) {
     return (this.boundingbox.left < tile.boundingBox.right) &&

--- a/public/js/HeroEntities.js
+++ b/public/js/HeroEntities.js
@@ -347,11 +347,13 @@ class Zerlin extends Entity {
   }
 
   enableInvincibility() {
-    if (this.invincible) { //if already invincible reset the timer.
-      this.iSeconds = Constants.PowerUpConstants.INVINCIBILITY_TIME;
-    } else {
-      this.invincible = true;
-    }
+    // if (this.invincible) { //if already invincible reset the timer.
+    //   this.iSeconds = Constants.PowerUpConstants.INVINCIBILITY_TIME;
+    // } else {
+    //   this.invincible = true;
+    // }
+    this.iSeconds = Constants.PowerUpConstants.INVINCIBILITY_TIME;
+    this.invincible = true;
   }
 
 
@@ -796,11 +798,13 @@ class Lightsaber extends Entity {
   }
 
   enableSplitLasers() {
-    if (this.splitLasers) { //if splitshot is already active, reset the timer
-      this.splitShotTimer = puc.SPLIT_SHOT_TIME;
-    } else {
-      this.splitLasers = true;
-    }
+    // if (this.splitLasers) { //if splitshot is already active, reset the timer
+    //   this.splitShotTimer = puc.SPLIT_SHOT_TIME;
+    // } else {
+    //   this.splitLasers = true;
+    // }
+    this.splitShotTimer = puc.SPLIT_SHOT_TIME;
+    this.splitLasers = true;
   }
 
   saberSlope() {

--- a/public/js/Level.js
+++ b/public/js/Level.js
@@ -73,6 +73,8 @@ class Level {
   _parseTiles() {
     var rows = this.levelLayout.length;
     var rowHeight = this.camera.height / rows;
+    this.length = this.levelLayout[0].length * this.tileWidth;
+    console.log("length - 7: " + this.getLengthAtI(7));
 
     for (let i = 0; i < rows; i++) {
       for (let j = 0; j < this.levelLayout[i].length; j++) {
@@ -185,6 +187,10 @@ class Level {
         tile.draw();
       }
     });
+  }
+  // method that will return the length of the level minus the offset of i.
+  getLengthAtI(i) {
+    return (this.levelLayout[0].length - i) * this.tileWidth;
   }
 
 }

--- a/public/js/Level.js
+++ b/public/js/Level.js
@@ -18,10 +18,14 @@ b  =  slow burst droid
 f  =  fast burst droid
 m  =  multi-shot droid
 n  =  sniper droid
+
 H  =  health powerup
 F  =  force powerup
 I  =  invincibility powerup
-*  = leggy droid boss
+S  =  split-shot powerup
+T  =  tiny mode powerup
+
+*  =  leggy droid boss
 X  =  Boss
 */
 
@@ -478,7 +482,7 @@ class ParallaxSnowBackground extends Entity {
     this.imageDistanceFromX = 0;
     this.scale = 10 * Math.pow(Math.E, -this.distanceFromCamera * .001);
     this.deltaY = 120000 / this.distanceFromCamera + SNOW_SPEED;
-    console.log(this.scale);
+    //console.log(this.scale);
   }
 
   instantiate(game, camera) {

--- a/public/js/Level.js
+++ b/public/js/Level.js
@@ -74,7 +74,6 @@ class Level {
     var rows = this.levelLayout.length;
     var rowHeight = this.camera.height / rows;
     this.length = this.levelLayout[0].length * this.tileWidth;
-    console.log("length - 7: " + this.getLengthAtI(7));
 
     for (let i = 0; i < rows; i++) {
       for (let j = 0; j < this.levelLayout[i].length; j++) {

--- a/public/js/PowerUp.js
+++ b/public/js/PowerUp.js
@@ -17,6 +17,10 @@ class AbstractPowerUp extends Entity {
     this.animation = null;
     this.randomYIntercept = Math.random() * Math.PI * 2;
     this.aliveTime = 0;
+
+    this.time = 0; //active time of powerup
+    this.smallScale = 0; //scale of powerup to be placed in powerupStatusBar.
+    
   }
   update() {
     super.update();
@@ -24,6 +28,8 @@ class AbstractPowerUp extends Entity {
     this.y = this.startY + puc.FLOATING_MAGNITUDE * Math.sin(3 * (this.aliveTime + this.randomYIntercept));
     this.boundCircle.y = this.y + this.radius;
   }
+
+  
 
   draw() {
     var camera = this.sceneManager.camera;
@@ -49,8 +55,12 @@ class AbstractPowerUp extends Entity {
       super.draw();
     }
   }
+  
   effect() {
     throw new Error("Can't instantiate AbstractPowerUp");
+  }
+  deactivate() {
+
   }
   playSound() {
     this.game.audio.playSoundFx(this.game.audio.item, 'itemPowerup');
@@ -133,10 +143,14 @@ class InvincibilityPowerUp extends AbstractPowerUp {
       x: this.x + this.radius,
       y: this.y + this.radius
     };
+
+    this.time = puc.INVINCIBILITY_TIME;
+    this.smallScale = 1.5;
   }
 
   effect() {
-    this.game.sceneManager.Zerlin.invincible = true;
+    //this.sceneManager.Zerlin.invincible = true;
+    this.sceneManager.Zerlin.enableInvincibility();
   }
 }
 
@@ -167,10 +181,14 @@ class SplitLaserPowerUp extends AbstractPowerUp {
       x: this.x + this.radius,
       y: this.y + this.radius
     };
+
+    this.time = puc.SPLIT_SHOT_TIME;
+    this.smallScale = 0.30;
   }
 
   effect() {
-    this.game.sceneManager.Zerlin.lightsaber.splitLasers = true;
+    //this.game.sceneManager.Zerlin.lightsaber.splitLasers = true;
+    this.sceneManager.Zerlin.lightsaber.enableSplitLasers();
   }
 }
 
@@ -188,6 +206,8 @@ class TinyModePowerUp extends AbstractPowerUp {
       x: this.x + this.radius,
       y: this.y + this.radius
     };
+    this.time = puc.TINY_MODE_TIME;
+    this.smallScale = 0.30;
   }
 
   effect() {

--- a/public/js/SceneManager.js
+++ b/public/js/SceneManager.js
@@ -503,7 +503,7 @@ class SceneManager2 {
 
 
   if (this.boss && !this.boss.alive || (this.boss == null && this.level.unspawnedBoss == null 
-        && this.droids.length == 0 && this.level.unspawnedDroids.length == 0) && !this.wonLevel) {
+        && this.droids.length == 0 && this.Zerlin.x >= this.level.getLengthAtI(5)) && !this.wonLevel) {
           //also need to check if zerlin is near the end of the level when there is no boss.
 		this.wonLevel = true;
 		this.boss = null;
@@ -516,6 +516,7 @@ class SceneManager2 {
 		}
 	}
 	if (this.wonLevel) {
+    console.log("won level");
     this.newLevel = true;
 		this.timeSinceBossDeath += this.game.clockTick;
 		if (this.timeSinceBossDeath > smc.LEVEL_COMPLETE_OVERLAY_TIME) {

--- a/public/js/SceneManager.js
+++ b/public/js/SceneManager.js
@@ -46,6 +46,7 @@ class SceneManager2 {
       this.game.assetManager.getAsset('../img/music_menu_xmusic.png'),
       this.game.assetManager.getAsset('../img/music_menu_xfx.png')
     ]);
+    this.godMode = false;
   }
 
   init() {
@@ -630,6 +631,17 @@ class SceneManager2 {
   //________________________________________________________
   saveProgress() {
 
+  }
+
+  toggleGodMode() {
+    if (this.godMode) {
+      this.godMode = false;
+      this.Zerlin.godMode = false;
+    } else {
+      this.godMode = true;
+      this.Zerlin.godMode = true;
+    }
+    this.Zerlin.setHealth();
   }
 }
 

--- a/public/js/SceneManager.js
+++ b/public/js/SceneManager.js
@@ -76,8 +76,8 @@ class SceneManager2 {
     var CITY_LEVEL_BACKGROUNDS = [
       new ParallaxScrollBackground(this.game, this, '../img/city_background.png', 1, 5200),
       new ParallaxScrollBackground(this.game, this, '../img/city_buildings_back.png', 1, 2500),
-      new ParallaxScrollBackground(this.game, this, '../img/city_buildings_middle.png', 1, 1000),
-      new ParallaxScrollBackground(this.game, this, '../img/city_buildings_foreground.png', 1, 1400),
+      new ParallaxScrollBackground(this.game, this, '../img/city_buildings_middle.png', 1, 1400),
+      new ParallaxScrollBackground(this.game, this, '../img/city_buildings_foreground.png', 1, 1000),
       new ParallaxFloatingBackground(this.game, this, '../img/city_clouds_left.png', 1, 800),
       new ParallaxFloatingBackground(this.game, this, '../img/city_clouds2.png', 1, 12000),
       new ParallaxFloatingBackground(this.game, this, '../img/city_clouds_center.png', 1, 600)

--- a/public/js/SceneManager.js
+++ b/public/js/SceneManager.js
@@ -505,6 +505,7 @@ class SceneManager2 {
   if (this.boss && !this.boss.alive || (this.boss == null && this.level.unspawnedBoss == null 
         && this.droids.length == 0 && this.Zerlin.x >= this.level.getLengthAtI(5)) && !this.wonLevel) {
           //also need to check if zerlin is near the end of the level when there is no boss.
+    console.log("level won");
 		this.wonLevel = true;
 		this.boss = null;
 		this.saveProgress();
@@ -516,7 +517,6 @@ class SceneManager2 {
 		}
 	}
 	if (this.wonLevel) {
-    console.log("won level");
     this.newLevel = true;
 		this.timeSinceBossDeath += this.game.clockTick;
 		if (this.timeSinceBossDeath > smc.LEVEL_COMPLETE_OVERLAY_TIME) {

--- a/public/js/SceneManager.js
+++ b/public/js/SceneManager.js
@@ -51,9 +51,9 @@ class SceneManager2 {
   init() {
     this.buildLevels();
     document.getElementById("formOverlay").style.display = "none";
-    this.startOpeningScene();
+    //this.startOpeningScene();
     /* skip intro stuff and go strait to the level */
-    // this.startLevelScene();
+     this.startLevelScene();
     // document.getElementById("formOverlay").style.display = "none"; // hide login if not hid in css (curently is)
   }
 
@@ -150,6 +150,26 @@ class SceneManager2 {
 
   addPowerup(powerup) {
     this.powerups.push(powerup);
+  }
+  addActivePowerup(powerup) {
+    if (this.activePowerups.length == 0) {
+      this.activePowerups.push(new PowerupStatusBar(this.game, this, 0, 0, powerup));
+    } else {
+      var powerupExists = false;
+      var pStatusBar;
+      for (var i = 0; i < this.activePowerups.length; i++) {
+        var activePowerup = this.activePowerups[i].getPowerup();
+        if (powerup.constructor.name === activePowerup.constructor.name) {
+          powerupExists = true;
+          pStatusBar = this.activePowerups[i];
+        }
+      }
+      if (powerupExists) {
+        pStatusBar.reset();
+      } else {
+        this.activePowerups.push(new PowerupStatusBar(this.game, this, 0, 0, powerup));
+      }
+    }
   }
 
   pause() { // todo: pause music as well
@@ -375,6 +395,7 @@ class SceneManager2 {
     this.beams = [];
     this.powerups = [];
     this.otherEntities = [];
+    this.activePowerups = [];
     this.boss = null;
     this.bossMusicSwitched = false;
     this.bossHealthBar = null;
@@ -436,6 +457,12 @@ class SceneManager2 {
         this.powerups[i].update();
         if (this.powerups[i].removeFromWorld) {
           this.powerups.splice(i, 1);
+        }
+      }
+      for (var i = this.activePowerups.length - 1; i >= 0; i--) {
+        this.activePowerups[i].update(i);
+        if (this.activePowerups[i].removeFromWorld) {
+          this.activePowerups.splice(i, 1);
         }
       }
       for (var i = this.otherEntities.length - 1; i >= 0; i--) {
@@ -531,6 +558,9 @@ class SceneManager2 {
     }
     for (var i = 0; i < this.powerups.length; i++) {
       this.powerups[i].draw(this.ctx);
+    }
+    for (var i = 0; i < this.activePowerups.length; i++) {
+      this.activePowerups[i].draw();
     }
     for (var i = 0; i < this.otherEntities.length; i++) {
       this.otherEntities[i].draw(this.ctx);

--- a/public/js/SceneManager.js
+++ b/public/js/SceneManager.js
@@ -123,7 +123,7 @@ class SceneManager2 {
     this.levelBackgrounds = [];
     this.levels.push(new Level(this.game, this, lvlConst.MIKE_LEVEL_ONE, LEVEL_ONE_BACKGROUNDS, LEVEL_ONE_TILES));
     this.levels.push(new Level(this.game, this, lvlConst.CITY_LEVEL, CITY_LEVEL_BACKGROUNDS, CITY_LEVEL_TILES));
-    this.levels.push(new Level(this.game, this, lvlConst.MIKE_LEVEL_ONE, LEVEL_THREE_BACKGROUNDS, LEVEL_THREE_TILES));
+    this.levels.push(new Level(this.game, this, lvlConst.MIKE_LEVEL_TWO, LEVEL_THREE_BACKGROUNDS, LEVEL_THREE_TILES));
   }
 
   setCheckPoint(checkPoint) {

--- a/public/js/SceneManager.js
+++ b/public/js/SceneManager.js
@@ -504,6 +504,7 @@ class SceneManager2 {
 
   if (this.boss && !this.boss.alive || (this.boss == null && this.level.unspawnedBoss == null 
         && this.droids.length == 0 && this.level.unspawnedDroids.length == 0) && !this.wonLevel) {
+          //also need to check if zerlin is near the end of the level when there is no boss.
 		this.wonLevel = true;
 		this.boss = null;
 		this.saveProgress();
@@ -528,6 +529,7 @@ class SceneManager2 {
 	}
     if (!this.startedFinalOverlay && !this.Zerlin.alive &&
       this.Zerlin.timeOfDeath + this.Zerlin.deathAnimation.totalTime < this.levelSceneTimer) {
+      this.canPause = false;
       this.startedFinalOverlay = true;
       this.sceneEntities.push(new Overlay(this.game, false, smc.LEVEL_TRANSITION_OVERLAY_TIME));
       this.sceneEntities.push(new GameOverTextScreen(this.game));
@@ -536,7 +538,8 @@ class SceneManager2 {
       this.game.audio.playBackgroundSong();
       this.startNewScene = true;
     }
-    if (this.stopLevelTime < this.levelSceneTimer && this.startNewScene) {
+    if (this.stopLevelTime < this.levelSceneTimer && this.startNewScene ||
+        (!this.canPause && this.game.keys['Enter'])) {
       this.game.audio.endAllSoundFX();
       this.startLevelTransitionScene();
       this.startNewScene = false;

--- a/public/js/SceneManager.js
+++ b/public/js/SceneManager.js
@@ -501,7 +501,9 @@ class SceneManager2 {
       // this.gameEngine.startInput();
     }
 
-	if (this.boss && !this.boss.alive) {
+
+  if (this.boss && !this.boss.alive || (this.boss == null && this.level.unspawnedBoss == null 
+        && this.droids.length == 0 && this.level.unspawnedDroids.length == 0) && !this.wonLevel) {
 		this.wonLevel = true;
 		this.boss = null;
 		this.saveProgress();
@@ -513,6 +515,7 @@ class SceneManager2 {
 		}
 	}
 	if (this.wonLevel) {
+    this.newLevel = true;
 		this.timeSinceBossDeath += this.game.clockTick;
 		if (this.timeSinceBossDeath > smc.LEVEL_COMPLETE_OVERLAY_TIME) {
 			this.levelNumber++;

--- a/public/js/StatusBar.js
+++ b/public/js/StatusBar.js
@@ -320,7 +320,7 @@ class PowerupStatusBar extends Entity {
     this.powerup.animation.scale = powerup.smallScale;
     this.y = sbc.POWERUP_Y;
 
-    this.color = 'green';
+    this.color = 'rgb(57, 255, 20)';
   }
   update(i) {
     super.update();

--- a/public/js/StatusBar.js
+++ b/public/js/StatusBar.js
@@ -125,9 +125,6 @@ class AbstractStatusBar extends Entity {
         ctx.closePath();
 
       }
-
-
-
       //draw the text of the status bar current/maxSize
       if (this.displayText) {
         ctx.fillText(`${this.current} / ${this.maxSize}`, this.x + this.maxLength / 2,
@@ -136,8 +133,6 @@ class AbstractStatusBar extends Entity {
 
       ctx.restore();
     }
-
-
 
   }
 
@@ -305,5 +300,63 @@ class DroidBossHealthStatusBar extends AbstractStatusBar {
       this.game.ctx.drawImage(this.image, this.x - 65, this.y - 30,
         50, 50);
     }
+  }
+}
+
+/*
+* Powerups status bar, will call powerup deactivate when 
+* In order to use properly, powerup needs to have the time field which holds the max powerup time.
+*/
+    
+class PowerupStatusBar extends Entity {
+  constructor(game, sceneManager, x, y, powerup) {
+    super(game, x, y);
+    this.sceneManager = sceneManager;
+    this.powerup = powerup; //powerup to call deactivate on
+
+    this.maxPowerupTime = this.powerup.time;
+    this.currentPowerupTime = this.powerup.time;
+
+    this.powerup.animation.scale = powerup.smallScale;
+    this.y = sbc.POWERUP_Y;
+
+    this.color = 'green';
+  }
+  update(i) {
+    super.update();
+    this.currentPowerupTime -= this.game.clockTick;
+    if (this.currentPowerupTime <= 0) {
+      this.removeFromWorld = true;
+    }
+    this.x = sbc.POWERUP_START_X + (i * sbc.POWERUP_PAD_X);
+
+  }
+  draw() {
+    super.draw();
+    var animation = this.powerup.animation;
+    var ctx = this.game.ctx;
+    if (animation != null) {
+      ctx.save();
+
+      ctx.lineWidth = 4;
+      ctx.strokeStyle = this.color;
+      ctx.lineCap = "round";
+      if (this.currentPowerupTime > 0) {
+        ctx.beginPath();
+        ctx.moveTo(this.x, this.y+sbc.POWERUP_BAR_Y);
+        ctx.lineTo(this.x + ((sbc.POWERUP_LENGTH / this.maxPowerupTime) * this.currentPowerupTime), 
+            this.y + sbc.POWERUP_BAR_Y);
+        ctx.stroke();
+        ctx.closePath();
+      }
+      ctx.restore();
+      animation.drawFrame(this.game.clockTick, ctx, this.x, this.y);
+    }
+  }
+  reset() {
+    this.currentPowerupTime = this.maxPowerupTime;
+  }
+  getPowerup() {
+    return this.powerup;
   }
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -46,6 +46,11 @@
       <!-- width = height * PHI -->
       <canvas id="gameWorld" tabindex="1" width="1133" height="700" style="border: 1px solid black; background: black"></canvas>
     </div>
+    
+    <!-- cheat buttons -->
+    <div class="cheat_buttons">
+      <input type="button" id="godMode" value="God Mode" style="float: right;">
+    </div>
 
     <div class="instructions">
       <hr>
@@ -65,6 +70,7 @@
           </p>
       </span>
     </div>
+    
 
   </div>
 


### PR DESCRIPTION
Implementation for the status bar. 
- the activePowerups in the sceneManager holds the powerup status bars.
Easiest way to implement was to keep current timer implementation.

- BUG: picking up tiny powerup twice will make zerlin very VERY small.
